### PR TITLE
Fix TypeScript errors in Notification type

### DIFF
--- a/app/admin/schedule/page.tsx
+++ b/app/admin/schedule/page.tsx
@@ -39,7 +39,7 @@ export default function SchedulePage() {
 
   // Use real-time sync
   const { syncData, lastSync } = useRealtimeSync({
-    hospitalId: selectedHospitalId,
+    hospitalId: selectedHospitalId || undefined,
     year: viewYear,
     month: viewMonth
   })
@@ -109,7 +109,7 @@ export default function SchedulePage() {
       setShowOptionsModal(false)
       // Sync data to get latest updates
       syncData()
-    } catch (error: any) {
+    } catch (error) {
       // Error is already shown by updateShift
     }
     setShowAssignModal(false)

--- a/contexts/DataContext.tsx
+++ b/contexts/DataContext.tsx
@@ -216,9 +216,9 @@ export const DataProvider: React.FC<DataProviderProps> = ({ children }) => {
         }))
         addNotification('Shift updated successfully', 'success')
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error('Error updating shift:', error)
-      addNotification(error.message || 'Failed to update shift', 'error')
+      addNotification(error instanceof Error ? error.message : 'Failed to update shift', 'error')
       throw error
     }
   }

--- a/types/index.ts
+++ b/types/index.ts
@@ -34,7 +34,7 @@ export interface Hospital {
 
 export interface Notification {
   id: number
-  type: string
+  type: 'success' | 'error' | 'info' | 'warning'
   title: string
   message: string
   read: boolean


### PR DESCRIPTION
- Remove overly broad string union from Notification type definition
- Fix to use strict type literals only: 'success'  < /dev/null |  'error' | 'info' | 'warning'
- TypeScript compilation now passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)